### PR TITLE
fix: Attempt using /data/bot_data.db for SQLite path

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ class RSSTelegramBot:
     """Main class for the RSS Telegram Bot."""
     SIMILARITY_THRESHOLD = 0.75
     DUPLICATE_TITLE_WINDOW_SECONDS = 48 * 60 * 60  # 48 hours
-    DB_PATH = "/app/bot_data.db"
+    DB_PATH = "/data/bot_data.db"
 
     def __init__(self, bot_token: str, target_channel: str):
         self.bot_token = bot_token


### PR DESCRIPTION
Changing DB_PATH to /data/bot_data.db as /app/bot_data.db continues to cause 'unable to open database file'. The /data directory is often used for persistent storage on Hugging Face Spaces.