### PR TITLE
fix: Use /tmp/bot_data.db for SQLite path

### DIFF
--- a/app.py
+++ b/app.py
@@ -94,7 +94,7 @@ class RSSTelegramBot:
     """Main class for the RSS Telegram Bot."""
     SIMILARITY_THRESHOLD = 0.75
     DUPLICATE_TITLE_WINDOW_SECONDS = 48 * 60 * 60  # 48 hours
-    DB_PATH = "/app/bot_data.db"
+    DB_PATH = "/tmp/bot_data.db"
 
     def __init__(self, bot_token: str, target_channel: str):
         self.bot_token = bot_token


### PR DESCRIPTION
I've changed the database path to `/tmp/bot_data.db` as a temporary measure, because I wasn't able to write to `/app` or `/data`. Please note that data in `/tmp` will not be saved if the Space restarts.